### PR TITLE
Expand documentation comments across app

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,4 +103,10 @@ TMDB_IMAGE_BASE=https://image.tmdb.org/t/p
 - The UI uses Tailwind CSS (JIT via tailwindcss v4 + `@tailwindcss/postcss`).
 - All Supabase mutations go through server actions with centralized gating and revalidation.
 
+## Code Documentation
+
+- The TypeScript and React source files now include comprehensive doc comments describing component responsibilities, server actions, and utility helpers.
+- Look for `/** ... */` blocks above exports for quick insights into data flow, plan gating, and TMDB integration details.
+- Core modules in `src/lib`, authenticated route files under `src/app/(app)`, and UI providers/components all document their side effects and integration points so new contributors can trace behaviour end-to-end.
+
 Happy building!

--- a/src/app/(app)/app/page.tsx
+++ b/src/app/(app)/app/page.tsx
@@ -1,8 +1,13 @@
+/**
+ * Authenticated dashboard route showing the user's collections and create
+ * controls. All reads happen on the server so the dashboard can stream data
+ * immediately after authentication.
+ */
+
 import { redirect } from "next/navigation";
 import { CollectionsDashboard } from "@/components/collections/collections-dashboard";
 import { getSupabaseServerClient } from "@/lib/supabase/server";
 import type { Profile } from "@/lib/supabase/types";
-
 export default async function DashboardPage() {
   const supabase = await getSupabaseServerClient();
   const { data: userData, error: userError } = await supabase.auth.getUser();
@@ -36,6 +41,9 @@ export default async function DashboardPage() {
     throw collectionsError;
   }
 
+  // Flatten the nested count aggregate to the shape expected by the dashboard
+  // component. We expose `item_count` rather than the raw relationship to keep
+  // the UI decoupled from Supabase response formats.
   const collections = (collectionsData ?? []).map((collection) => ({
     id: collection.id,
     title: collection.title,

--- a/src/app/(app)/collections/[collectionId]/page.tsx
+++ b/src/app/(app)/collections/[collectionId]/page.tsx
@@ -1,3 +1,8 @@
+/**
+ * Server component for the authenticated collection editor. It gathers all
+ * collection metadata, associated items, and cached TMDB movies before handing
+ * the data off to the interactive editor UI.
+ */
 
 import { notFound, redirect } from "next/navigation";
 import { CollectionEditor } from "@/components/collections/collection-editor";
@@ -5,10 +10,16 @@ import { getSupabaseServerClient } from "@/lib/supabase/server";
 import type { Profile, Movie } from "@/lib/supabase/types";
 import type { CollectionItemWithMovie } from "@/types/collection";
 
+/**
+ * Route params accepted by the collection editor page.
+ */
 interface PageParams {
   params: Promise<{ collectionId: string }> | { collectionId: string };
 }
 
+/**
+ * Server-rendered collection editor that loads collection data, movies, and passes them to the editor UI.
+ */
 export default async function CollectionEditorPage({ params }: PageParams) {
   const { collectionId } = await params;
   const supabase = await getSupabaseServerClient();
@@ -65,6 +76,9 @@ export default async function CollectionEditorPage({ params }: PageParams) {
     }
   }
 
+  // Combine the raw collection items with their cached TMDB metadata, filling
+  // in optional fields (overview, vote average) from the JSON payload to avoid
+  // issuing additional TMDB requests on the client.
   const mappedItems: CollectionItemWithMovie[] = items
     .map((item) => {
       const movie = moviesMap.get(item.tmdb_id) ?? null;

--- a/src/app/(app)/collections/actions.ts
+++ b/src/app/(app)/collections/actions.ts
@@ -10,12 +10,18 @@ import { getSupabaseServiceRoleClient } from "@/lib/supabase/service";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Collection, Database, Profile } from "@/lib/supabase/types";
 
+/**
+ * Payload used when creating a new collection from the dashboard.
+ */
 interface CreateCollectionInput {
   title: string;
   description?: string | null;
   isPublic?: boolean;
 }
 
+/**
+ * Loads the authenticated profile and server Supabase client or throws descriptive errors.
+ */
 async function getProfileOrThrow() {
   const cookieStore = await cookies();
   const supabase = await createSupabaseServerClient(cookieStore);
@@ -42,6 +48,9 @@ async function getProfileOrThrow() {
   return { profile: data as Profile, supabase, userId: user.id };
 }
 
+/**
+ * Revalidates the public collection route when relevant data changes.
+ */
 async function revalidatePublicCollection(profile: Profile, supabase: SupabaseClient<Database>, collectionId: string) {
   const { data } = await supabase
     .from("collections")
@@ -54,6 +63,9 @@ async function revalidatePublicCollection(profile: Profile, supabase: SupabaseCl
   }
 }
 
+/**
+ * Creates a new collection after enforcing plan limits and unique slugs.
+ */
 export async function createCollectionAction(input: CreateCollectionInput) {
   const title = input.title?.trim();
   if (!title) {
@@ -100,6 +112,9 @@ export async function createCollectionAction(input: CreateCollectionInput) {
   return data as Collection;
 }
 
+/**
+ * Updates collection metadata (title, description, visibility) and handles slug revalidation.
+ */
 export async function updateCollectionDetailsAction({
   collectionId,
   title,
@@ -180,6 +195,9 @@ export async function updateCollectionDetailsAction({
   return { ok: true } as const;
 }
 
+/**
+ * Deletes a collection owned by the authenticated user and revalidates dependent paths.
+ */
 export async function deleteCollectionAction(collectionId: string) {
   const { profile, supabase, userId } = await getProfileOrThrow();
 
@@ -204,6 +222,9 @@ export async function deleteCollectionAction(collectionId: string) {
   return { ok: true } as const;
 }
 
+/**
+ * Payload accepted when adding a TMDB movie to a collection.
+ */
 interface AddMovieInput {
   collectionId: string;
   movie: {
@@ -218,6 +239,9 @@ interface AddMovieInput {
   };
 }
 
+/**
+ * Inserts a TMDB movie into a collection and caches its metadata.
+ */
 export async function addMovieToCollectionAction(input: AddMovieInput) {
   const { profile, supabase, userId } = await getProfileOrThrow();
   const { collectionId, movie } = input;
@@ -276,6 +300,9 @@ export async function addMovieToCollectionAction(input: AddMovieInput) {
   return { ok: true } as const;
 }
 
+/**
+ * Removes a collection item after verifying ownership.
+ */
 export async function removeCollectionItemAction({
   collectionItemId,
   collectionId,
@@ -308,6 +335,9 @@ export async function removeCollectionItemAction({
   return { ok: true } as const;
 }
 
+/**
+ * Updates the note attached to a specific collection item.
+ */
 export async function updateCollectionItemNoteAction({
   collectionItemId,
   note,
@@ -341,6 +371,9 @@ export async function updateCollectionItemNoteAction({
   return { ok: true } as const;
 }
 
+/**
+ * Persists a new order for collection items based on drag-and-drop results.
+ */
 export async function reorderCollectionItemsAction({
   collectionId,
   orderedIds,

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,9 +1,18 @@
+/**
+ * Layout used for all authenticated routes under `/app`. It performs a
+ * server-side auth check and guarantees that a profile record exists before
+ * rendering the shared `AppShell` navigation.
+ */
+
 import { redirect } from "next/navigation";
 import { AppShell } from "@/components/layout/app-shell";
 import { ensureProfile } from "@/lib/auth";
 import { getSupabaseServerClient } from "@/lib/supabase/server";
 import type { Profile } from "@/lib/supabase/types";
 
+/**
+ * Authenticated layout that ensures a user profile exists before rendering the app shell.
+ */
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const supabase = await getSupabaseServerClient();
   const [{ data: userData, error: userError }] = await Promise.all([

--- a/src/app/(app)/settings/profile/page.tsx
+++ b/src/app/(app)/settings/profile/page.tsx
@@ -1,3 +1,8 @@
+/**
+ * Server component powering the profile settings page. Auth checks happen here
+ * so the client form can stay focused on presentation.
+ */
+
 import { redirect } from "next/navigation";
 import { ProfileSettingsForm } from "@/components/profile/profile-settings-form";
 import { getSupabaseServerClient } from "@/lib/supabase/server";

--- a/src/app/(auth)/auth/sign-in/page.tsx
+++ b/src/app/(auth)/auth/sign-in/page.tsx
@@ -1,3 +1,8 @@
+/**
+ * Main sign-in page. Auth checks run on the server to keep the client form free
+ * of conditional rendering.
+ */
+
 import { redirect } from "next/navigation";
 import { SignInForm } from "@/components/auth/sign-in-form";
 import { getSupabaseServerClient } from "@/lib/supabase/server";

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -1,5 +1,8 @@
 import { redirect } from "next/navigation";
 
+/**
+ * Legacy `/sign-in` alias that forwards traffic to `/auth/sign-in`.
+ */
 export default function SignInAliasPage() {
   redirect("/auth/sign-in");
 }

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,5 +1,8 @@
 import { redirect } from "next/navigation";
 
+/**
+ * Maintains backward compatibility for `/signin` by redirecting to the canonical route.
+ */
 export default function LegacySignInRedirect() {
   redirect("/auth/sign-in");
 }

--- a/src/app/api/tmdb/movie/route.ts
+++ b/src/app/api/tmdb/movie/route.ts
@@ -1,3 +1,9 @@
+/**
+ * API route that proxies movie detail lookups through our TMDB integration
+ * layer. Using the shared handler keeps rate limiting and caching consistent
+ * between search and detail endpoints.
+ */
+
 import type { NextRequest } from "next/server";
 import { handleMovie } from "@/lib/tmdb";
 

--- a/src/app/api/tmdb/search/route.ts
+++ b/src/app/api/tmdb/search/route.ts
@@ -1,3 +1,8 @@
+/**
+ * API route that proxies TMDB search queries. All heavy lifting happens in the
+ * shared handler so the route remains a thin wrapper for error logging.
+ */
+
 import type { NextRequest } from "next/server";
 import { handleSearch } from "@/lib/tmdb";
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,8 @@
+/**
+ * Root Next.js layout responsible for wiring fonts, global providers, and
+ * bootstrapping authenticated context for every page.
+ */
+
 import type { Metadata } from "next";
 import type { Session } from "@supabase/supabase-js";
 import { Inter, Playfair_Display } from "next/font/google";
@@ -8,18 +13,27 @@ import type { Profile } from "@/lib/supabase/types";
 import { cn } from "@/lib/utils";
 import "./globals.css";
 
+/**
+ * Primary sans-serif font used throughout the app.
+ */
 const inter = Inter({
   subsets: ["latin"],
   variable: "--font-inter",
   display: "swap",
 });
 
+/**
+ * Serif font used for display headings.
+ */
 const playfair = Playfair_Display({
   subsets: ["latin"],
   variable: "--font-playfair",
   display: "swap",
 });
 
+/**
+ * Default metadata applied to every page unless overridden.
+ */
 export const metadata: Metadata = {
   title: {
     template: "%s | FrameVault",
@@ -41,6 +55,9 @@ export const metadata: Metadata = {
   },
 };
 
+/**
+ * Wraps every page with global fonts and providers, ensuring Supabase sessions are available.
+ */
 export default async function RootLayout({
   children,
 }: Readonly<{
@@ -58,6 +75,9 @@ export default async function RootLayout({
 
   let profile: Profile | null = null;
   if (user) {
+    // Server components render during navigation and initial page loads, so we
+    // resolve the profile here and fall back to automatically creating one when
+    // a new account signs in for the first time.
     const { data } = await supabase
       .from("profiles")
       .select("*")

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,25 @@
+/**
+ * Public marketing landing page for FrameVault. This file intentionally avoids
+ * server data fetching so it can be statically rendered while still reusing our
+ * shared UI primitives.
+ */
+
 import { ArrowRight, Clapperboard, Sparkles } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
+/**
+ * Marketing bullet points shown on the landing page tour section.
+ */
 const highlights = [
   "Create cinematic collections in minutes",
   "Drag-and-drop sequencing with instant sync",
   "Public pages to share your curation",
 ];
 
+/**
+ * Public marketing page introducing FrameVault and linking to the app.
+ */
 export default function LandingPage() {
   return (
     <main className="relative isolate min-h-screen overflow-hidden">

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -1,12 +1,17 @@
 "use client";
 
+/**
+ * Client-side sign-in/sign-up form that talks directly to Supabase auth while
+ * handling mode toggles and demo credentials messaging. The component stays
+ * self-contained so the page can remain a simple wrapper.
+ */
+
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useSupabase } from "@/components/providers/supabase-provider";
 import { formatError } from "@/lib/utils";
-
 export function SignInForm() {
   const router = useRouter();
   const params = useSearchParams();
@@ -19,6 +24,11 @@ export function SignInForm() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  /**
+   * Handles form submission by performing either a password sign-in or sign-up
+   * request, then refreshing the session context so protected routes render
+   * immediately.
+   */
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);

--- a/src/components/collections/movie-search-modal.tsx
+++ b/src/components/collections/movie-search-modal.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+/**
+ * Modal for searching TMDB and selecting a movie to add to a collection. All
+ * data fetching happens client-side against our proxied API routes.
+ */
+
 import Image from "next/image";
 import { useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
@@ -8,6 +13,9 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { MovieSummary } from "@/lib/tmdb";
 
+/**
+ * Props controlling the TMDB movie search modal.
+ */
 interface MovieSearchModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -15,12 +23,19 @@ interface MovieSearchModalProps {
   existingTmdbIds: number[];
 }
 
+/**
+ * Modal dialog that lets users search TMDB and add movies to a collection.
+ */
 export function MovieSearchModal({ open, onOpenChange, onSelect, existingTmdbIds }: MovieSearchModalProps) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<MovieSummary[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  /**
+   * Queries the TMDB search API and stores the resulting list of movies. Results
+   * are filtered client-side to prevent selecting duplicates.
+   */
   async function handleSearch(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (query.trim().length < 2) {

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+/**
+ * Authenticated layout frame including sidebar navigation, user summary, and
+ * sign-out controls. Client-side to access Supabase context helpers.
+ */
+
 import { Film, LayoutDashboard, LogOut, Settings } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -8,16 +13,25 @@ import { useSupabase } from "@/components/providers/supabase-provider";
 import type { Profile } from "@/lib/supabase/types";
 import { cn } from "@/lib/utils";
 
+/**
+ * Props for the authenticated application shell layout.
+ */
 interface AppShellProps {
   children: React.ReactNode;
   profile: Profile;
 }
 
+/**
+ * Navigation options displayed in the sidebar for authenticated users.
+ */
 const navItems = [
   { href: "/app", label: "Dashboard", icon: LayoutDashboard },
   { href: "/settings/profile", label: "Profile", icon: Settings },
 ];
 
+/**
+ * Renders the authenticated layout with navigation, user info, and sign-out controls.
+ */
 export function AppShell({ children, profile }: AppShellProps) {
   const pathname = usePathname();
   const { signOut } = useSupabase();

--- a/src/components/media/poster-image.tsx
+++ b/src/components/media/poster-image.tsx
@@ -1,11 +1,22 @@
 "use client";
 
+/**
+ * Poster image component with resilient fallbacks. Handles TMDB outages by
+ * cycling through alternate sizes, service refresh calls, and local placeholders.
+ */
+
 import Image from "next/image";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 
+/**
+ * Local placeholder displayed when TMDB assets are unavailable.
+ */
 const FALLBACK_POSTER = "/images/poster-placeholder.svg";
 
+/**
+ * Props for the smart poster image component.
+ */
 interface PosterImageProps {
   src?: string | null;
   fallbackSrc?: string | null;
@@ -15,6 +26,9 @@ interface PosterImageProps {
   tmdbId?: number | null;
 }
 
+/**
+ * Intelligent poster image that handles TMDB fallbacks, alternate sizes, and cache refreshes.
+ */
 export function PosterImage({ src, fallbackSrc = null, alt, className, sizes = "100vw", tmdbId }: PosterImageProps) {
   const initial = src ?? fallbackSrc ?? null;
   const [posterSrc, setPosterSrc] = useState<string | null>(initial);
@@ -23,6 +37,8 @@ export function PosterImage({ src, fallbackSrc = null, alt, className, sizes = "
   const [isFetching, setIsFetching] = useState(false);
   const [sizeIndex, setSizeIndex] = useState(0);
 
+  // Predefined TMDB image widths to fall back through when a particular size is
+  // missing from the CDN cache.
   const tmdbSizeCandidates = useMemo(() => ["w500", "w780", "original"], []);
 
   useEffect(() => {
@@ -79,6 +95,9 @@ export function PosterImage({ src, fallbackSrc = null, alt, className, sizes = "
 
   const resolvedSrc = failed || !posterSrc ? FALLBACK_POSTER : posterSrc;
 
+  /**
+   * Attempts to derive the next available TMDB poster size when the current one fails.
+   */
   function nextTmdbSize(currentUrl: string) {
     const match = currentUrl.match(/\/t\/p\/(w\d+|original)\//);
     if (!match) return null;

--- a/src/components/plan/plan-gate.tsx
+++ b/src/components/plan/plan-gate.tsx
@@ -1,8 +1,15 @@
 "use client";
 
+/**
+ * Simple upsell component used when plan limits block an action.
+ */
+
 import { Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
+/**
+ * Props for the `PlanGate` upsell component shown when a feature is restricted by plan.
+ */
 interface PlanGateProps {
   title: string;
   message: string;
@@ -10,6 +17,9 @@ interface PlanGateProps {
   onCtaClick?: () => void;
 }
 
+/**
+ * Displays a locked card with messaging encouraging users to upgrade their plan.
+ */
 export function PlanGate({ title, message, ctaLabel = "View plans", onCtaClick }: PlanGateProps) {
   return (
     <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-indigo-500/30 bg-indigo-500/10 p-8 text-center text-slate-200">

--- a/src/components/profile/profile-settings-form.tsx
+++ b/src/components/profile/profile-settings-form.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+/**
+ * Interactive profile settings form that syncs with the Supabase context after
+ * a successful update.
+ */
+
 import { useEffect, useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -8,6 +13,9 @@ import { useToast } from "@/components/providers/toast-provider";
 import type { Profile } from "@/lib/supabase/types";
 import { updateProfileAction } from "@/app/(app)/settings/actions";
 
+/**
+ * Client form for updating a user's public display name and username.
+ */
 export function ProfileSettingsForm({ profile }: { profile: Profile }) {
   const { setProfile } = useSupabase();
   const { toast } = useToast();
@@ -23,6 +31,9 @@ export function ProfileSettingsForm({ profile }: { profile: Profile }) {
     return () => clearTimeout(timer);
   }, [message]);
 
+  /**
+   * Submits the profile update via server action and surfaces toast feedback.
+   */
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);

--- a/src/components/providers/app-providers.tsx
+++ b/src/components/providers/app-providers.tsx
@@ -1,17 +1,28 @@
 "use client";
 
+/**
+ * Composition root for all client-side providers. Keeps page/layout files tidy
+ * by hiding the provider wiring in a single component.
+ */
+
 import type { Session } from "@supabase/supabase-js";
 import type { Profile } from "@/lib/supabase/types";
 import { ReactQueryProvider } from "./react-query-provider";
 import { SupabaseProvider } from "./supabase-provider";
 import { ToastProvider } from "./toast-provider";
 
+/**
+ * Props for the root provider composition component.
+ */
 interface AppProvidersProps {
   children: React.ReactNode;
   initialSession?: Session | null;
   initialProfile?: Profile | null;
 }
 
+/**
+ * Mounts all global React providers (React Query, Toasts, Supabase) for the client subtree.
+ */
 export function AppProviders({
   children,
   initialSession = null,

--- a/src/components/providers/react-query-provider.tsx
+++ b/src/components/providers/react-query-provider.tsx
@@ -1,9 +1,16 @@
 "use client";
 
+/**
+ * Thin wrapper around React Query that creates a client per browser session.
+ */
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useState } from "react";
 
+/**
+ * Provides a per-session React Query client and mounts devtools in non-production environments.
+ */
 export function ReactQueryProvider({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
 

--- a/src/components/providers/supabase-provider.tsx
+++ b/src/components/providers/supabase-provider.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+/**
+ * Supabase context provider responsible for managing client-side auth state,
+ * refreshing sessions, and exposing helper actions to the rest of the app.
+ */
+
 import { useRouter } from "next/navigation";
 import {
   createContext,
@@ -13,6 +18,9 @@ import type { Session, SupabaseClient } from "@supabase/supabase-js";
 import { getSupabaseBrowserClient } from "@/lib/supabase/client";
 import type { Database, Profile } from "@/lib/supabase/types";
 
+/**
+ * Shape of the Supabase context shared across the application.
+ */
 interface SupabaseContextValue {
   supabase: SupabaseClient<Database>;
   session: Session | null;
@@ -25,6 +33,9 @@ interface SupabaseContextValue {
 
 const SupabaseContext = createContext<SupabaseContextValue | null>(null);
 
+/**
+ * Fetches the current session and verified user concurrently, returning `null` if unauthenticated.
+ */
 async function fetchVerifiedSession(client: SupabaseClient<Database>): Promise<Session | null> {
   const [sessionResult, userResult] = await Promise.all([
     client.auth.getSession(),
@@ -44,6 +55,9 @@ async function fetchVerifiedSession(client: SupabaseClient<Database>): Promise<S
   return { ...session, user } as Session;
 }
 
+/**
+ * Wraps children with Supabase context, handling session verification and profile hydration.
+ */
 export function SupabaseProvider({
   children,
   initialSession = null,
@@ -184,6 +198,9 @@ export function SupabaseProvider({
   return <SupabaseContext.Provider value={value}>{children}</SupabaseContext.Provider>;
 }
 
+/**
+ * Hook for consuming the Supabase context. Throws when used outside of `SupabaseProvider`.
+ */
 export function useSupabase() {
   const ctx = useContext(SupabaseContext);
   if (!ctx) {

--- a/src/components/providers/toast-provider.tsx
+++ b/src/components/providers/toast-provider.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+/**
+ * Lightweight toast system built on Radix primitives. Manages a queue of
+ * notifications and exposes a simple hook.
+ */
+
 import { createContext, useCallback, useContext, useMemo, useState } from "react";
 import {
   Toast,
@@ -11,8 +16,14 @@ import {
   type ToastVariant,
 } from "@/components/ui/toast";
 
+/**
+ * Default time (ms) before a toast automatically dismisses.
+ */
 const DEFAULT_DURATION = 3000;
 
+/**
+ * Options accepted when showing a toast notification.
+ */
 interface ToastOptions {
   id?: string;
   title?: string;
@@ -21,6 +32,9 @@ interface ToastOptions {
   duration?: number;
 }
 
+/**
+ * Internal toast representation tracked in state.
+ */
 interface ToastRecord {
   id: string;
   title?: string;
@@ -30,6 +44,9 @@ interface ToastRecord {
   open: boolean;
 }
 
+/**
+ * Context value exposed to components via the `useToast` hook.
+ */
 interface ToastContextValue {
   toast: (options: ToastOptions) => string;
   dismiss: (id: string) => void;
@@ -37,6 +54,9 @@ interface ToastContextValue {
 
 const ToastContext = createContext<ToastContextValue | null>(null);
 
+/**
+ * Generates a stable unique identifier for toasts. Uses `crypto.randomUUID` when available.
+ */
 function generateId() {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return crypto.randomUUID();
@@ -44,6 +64,9 @@ function generateId() {
   return `toast-${Math.random().toString(36).slice(2, 11)}`;
 }
 
+/**
+ * Provides toast state management and renders the Radix toast primitives.
+ */
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = useState<ToastRecord[]>([]);
 
@@ -76,6 +99,8 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
         open: true,
       };
 
+      // Replace any existing toast with the same id and trim the queue to keep
+      // the viewport manageable on small screens.
       const filtered = current.filter((item) => item.id !== id);
       return [...filtered, next].slice(-4);
     });
@@ -114,6 +139,9 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
+/**
+ * Hook for accessing the toast context, ensuring the provider is mounted.
+ */
 export function useToast() {
   const context = useContext(ToastContext);
   if (!context) {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,10 +1,18 @@
 "use client";
 
+/**
+ * Shared button primitive used across the application. Encapsulates styling
+ * variants so feature modules can stay lean.
+ */
+
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
+/**
+ * Variants backing the shared `Button` component, aligning with the FrameVault design system.
+ */
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/80 disabled:pointer-events-none disabled:opacity-60",
   {
@@ -32,12 +40,18 @@ const buttonVariants = cva(
   }
 );
 
+/**
+ * Props accepted by the shared `Button` component, including support for variant and size styling.
+ */
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 
+/**
+ * FrameVault's primary button component. Supports Radix `Slot` rendering and visual variants.
+ */
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,8 +1,15 @@
 "use client";
 
+/**
+ * Standard text input styled to match the FrameVault palette.
+ */
+
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
+/**
+ * Styled text input used throughout forms. Applies consistent colors, padding, and focus rings.
+ */
 export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
   ({ className, type, ...props }, ref) => {
     return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,8 +1,15 @@
 "use client";
 
+/**
+ * Styled textarea component with consistent focus rings and colours.
+ */
+
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
+/**
+ * Multiline text input styled to match FrameVault's design tokens.
+ */
 export const Textarea = React.forwardRef<
   HTMLTextAreaElement,
   React.TextareaHTMLAttributes<HTMLTextAreaElement>

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+/**
+ * Thin wrappers around Radix toast primitives that align styling with the rest
+ * of the FrameVault UI.
+ */
+
 import * as ToastPrimitives from "@radix-ui/react-toast";
 import type {
   ToastCloseProps,
@@ -12,8 +17,14 @@ import { forwardRef } from "react";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+/**
+ * Supported visual variants for toasts surfaced by the shared toast provider.
+ */
 type ToastVariant = "default" | "success" | "error" | "info";
 
+/**
+ * Maps toast variants to their associated color classes.
+ */
 const variantClasses: Record<ToastVariant, string> = {
   default: "border-slate-800/70 bg-slate-950/90 text-slate-100",
   success: "border-emerald-500/40 bg-emerald-500/15 text-emerald-100",
@@ -21,12 +32,21 @@ const variantClasses: Record<ToastVariant, string> = {
   info: "border-indigo-500/40 bg-indigo-500/15 text-indigo-100",
 };
 
+/**
+ * Re-exported Radix toast provider used at the application root.
+ */
 export const ToastProvider = ToastPrimitives.Provider;
 
+/**
+ * Props accepted by the `Toast` component, extending Radix's primitives with a variant prop.
+ */
 export interface ToastProps extends ToastPrimitiveProps {
   variant?: ToastVariant;
 }
 
+/**
+ * Styled toast container that applies variant-specific colors and animations.
+ */
 export const Toast = forwardRef<React.ElementRef<typeof ToastPrimitives.Root>, ToastProps>(
   ({ className, variant = "default", ...props }, ref) => (
     <ToastPrimitives.Root
@@ -44,6 +64,9 @@ export const Toast = forwardRef<React.ElementRef<typeof ToastPrimitives.Root>, T
 );
 Toast.displayName = ToastPrimitives.Root.displayName;
 
+/**
+ * Bold title text rendered within a toast notification.
+ */
 export const ToastTitle = forwardRef<React.ElementRef<typeof ToastPrimitives.Title>, ToastTitleProps>(
   ({ className, ...props }, ref) => (
     <ToastPrimitives.Title ref={ref} className={cn("text-sm font-semibold", className)} {...props} />
@@ -51,6 +74,9 @@ export const ToastTitle = forwardRef<React.ElementRef<typeof ToastPrimitives.Tit
 );
 ToastTitle.displayName = ToastPrimitives.Title.displayName;
 
+/**
+ * Supplemental description copy that appears beneath a toast title.
+ */
 export const ToastDescription = forwardRef<
   React.ElementRef<typeof ToastPrimitives.Description>,
   ToastDescriptionProps
@@ -59,6 +85,9 @@ export const ToastDescription = forwardRef<
 ));
 ToastDescription.displayName = ToastPrimitives.Description.displayName;
 
+/**
+ * Close button rendered in the top-right corner of each toast.
+ */
 export const ToastClose = forwardRef<React.ElementRef<typeof ToastPrimitives.Close>, ToastCloseProps>(
   ({ className, ...props }, ref) => (
     <ToastPrimitives.Close
@@ -76,6 +105,9 @@ export const ToastClose = forwardRef<React.ElementRef<typeof ToastPrimitives.Clo
 );
 ToastClose.displayName = ToastPrimitives.Close.displayName;
 
+/**
+ * Container that positions toasts near the bottom of the viewport.
+ */
 export const ToastViewport = forwardRef<React.ElementRef<typeof ToastPrimitives.Viewport>, ToastViewportProps>(
   ({ className, ...props }, ref) => (
     <ToastPrimitives.Viewport

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+/**
+ * Environment schema validated on the server. Ensures critical secrets and URLs are present.
+ */
 const serverSchema = z.object({
   NEXT_PUBLIC_SITE_URL: z.string().url().default("http://localhost:3000"),
   NEXT_PUBLIC_SUPABASE_URL: z.string().url({ message: "NEXT_PUBLIC_SUPABASE_URL must be a valid URL" }),
@@ -20,6 +23,9 @@ const serverSchema = z.object({
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().optional(),
 });
 
+/**
+ * Subset of the environment exposed to the browser. Validated separately to avoid leaking secrets.
+ */
 const clientSchema = serverSchema.pick({
   NEXT_PUBLIC_SITE_URL: true,
   NEXT_PUBLIC_SUPABASE_URL: true,
@@ -34,6 +40,9 @@ type ClientEnv = z.infer<typeof clientSchema>;
 
 let serverEnvCache: ServerEnv | null = null;
 
+/**
+ * Reads and validates the process environment for server-only variables, caching the result.
+ */
 export function getServerEnv(): ServerEnv {
   if (serverEnvCache) return serverEnvCache;
   const parsed = serverSchema.safeParse(process.env);
@@ -45,6 +54,9 @@ export function getServerEnv(): ServerEnv {
   return serverEnvCache;
 }
 
+/**
+ * Validates and returns the environment values safe to expose to client code.
+ */
 export function getClientEnv(): ClientEnv {
   const parsed = clientSchema.safeParse({
     NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,8 +1,26 @@
+/**
+ * Utilities for building consistent API responses across server actions and
+ * Next.js route handlers. Centralising these helpers keeps every edge case
+ * (validation failures, rate limits, etc.) aligned so that consuming clients
+ * can rely on predictable shapes regardless of where a response originated.
+ */
+
+/**
+ * Standard JSON payload returned by API routes when an error occurs. The
+ * `error` field is a short, machine-friendly code whereas `message` surfaces a
+ * human-readable explanation that can be rendered directly to users.
+ */
 export interface ApiErrorPayload {
   error: string;
   message: string;
 }
 
+/**
+ * Helper for returning a JSON error response with a consistent structure and
+ * status code. Wrapping the response construction avoids subtle inconsistencies
+ * (missing headers, incorrect casing) when the pattern is repeated across many
+ * server actions.
+ */
 export function apiError(error: string, message: string, status = 400) {
   return new Response(JSON.stringify({ error, message }), {
     status,
@@ -10,6 +28,11 @@ export function apiError(error: string, message: string, status = 400) {
   });
 }
 
+/**
+ * Serialises the provided data as JSON while preserving any custom response
+ * init options. This mirrors `NextResponse.json` but keeps the abstraction
+ * lightweight so non-Next contexts (e.g., server actions) can share the helper.
+ */
 export function apiJson<T>(data: T, init?: ResponseInit) {
   return new Response(JSON.stringify(data), {
     ...init,
@@ -20,6 +43,12 @@ export function apiJson<T>(data: T, init?: ResponseInit) {
   });
 }
 
+/**
+ * Error class that carries an HTTP status code and short code for routing
+ * failures through shared handlers. Throwing an `ApiError` allows caller code to
+ * inspect the `status` and `code` properties and translate them into toast
+ * notifications or custom UI without having to parse strings.
+ */
 export class ApiError extends Error {
   public readonly status: number;
   public readonly code: string;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,8 +1,26 @@
+/**
+ * Authentication helpers shared across server components and server actions.
+ * These utilities encapsulate the boilerplate involved in reading Supabase's
+ * auth state and ensuring the companion `profiles` table stays in sync with the
+ * authenticated user. By keeping the logic here we avoid duplicating session
+ * fetching and profile hydration in every route.
+ */
+
 import type { Session } from "@supabase/supabase-js";
 import { getSupabaseServerClient } from "@/lib/supabase/server";
 import { getSupabaseServiceRoleClient } from "@/lib/supabase/service";
 import type { Profile } from "@/lib/supabase/types";
 
+/**
+ * Retrieves the current Supabase session and verified user in parallel.
+ *
+ * - Returns the merged session (with the `user` patched in) when both the
+ *   session cookie and Supabase auth API confirm an authenticated context.
+ * - Returns `null` when no session exists so that callers can gracefully render
+ *   marketing pages or redirect to sign-in.
+ * - Throws when Supabase returns an unexpected error so upstream handlers can
+ *   surface error boundaries.
+ */
 export async function getSession() {
   const supabase = await getSupabaseServerClient();
   const [sessionResult, userResult] = await Promise.all([
@@ -23,6 +41,15 @@ export async function getSession() {
   return { ...session, user } as Session;
 }
 
+/**
+ * Loads the profile row for the authenticated user if both the session and
+ * profile exist.
+ *
+ * Consumers often need to display profile metadata (username, plan tier) but
+ * can function when the profile is missing—so this helper explicitly returns
+ * `null` rather than throwing. That behaviour keeps server components easy to
+ * compose with optional profile UI.
+ */
 export async function getAuthenticatedProfile() {
   const supabase = await getSupabaseServerClient();
   const { data: userData, error } = await supabase.auth.getUser();
@@ -39,6 +66,14 @@ export async function getAuthenticatedProfile() {
   return data as Profile | null;
 }
 
+/**
+ * Ensures an authenticated request has an associated profile record.
+ *
+ * This helper is used in sensitive flows (e.g., server actions) where an
+ * authenticated user is mandatory. It double checks for an existing profile and
+ * provisions one via the service-role client when absent so downstream logic can
+ * assume the profile exists.
+ */
 export async function requireUserProfile() {
   const supabase = await getSupabaseServerClient();
   const { data: userData, error } = await supabase.auth.getUser();
@@ -62,6 +97,14 @@ export async function requireUserProfile() {
   return data as Profile;
 }
 
+/**
+ * Creates a `profiles` row when one does not already exist.
+ *
+ * The username is derived from the email prefix (falling back to a user-based
+ * slug) to give new accounts a sensible default for public collection URLs. The
+ * function returns the freshly inserted profile so callers can immediately use
+ * it in responses without an additional query.
+ */
 export async function ensureProfile(userId: string, email?: string | null) {
   const service = getSupabaseServiceRoleClient();
 

--- a/src/lib/plan.ts
+++ b/src/lib/plan.ts
@@ -1,17 +1,39 @@
+/**
+ * Plan gating helpers centralised in one module. Keeping the mapping between
+ * subscription tiers and collection limits here allows server actions and UI
+ * components to share the same source of truth when determining whether a user
+ * can create additional collections or requires an upgrade prompt.
+ */
+
 import type { Profile } from "@/lib/supabase/types";
 
+/**
+ * Lookup table describing how many collections each plan tier is allowed to
+ * create. A value of `null` represents unlimited collections for the tier.
+ */
 export const PLAN_COLLECTION_LIMIT: Record<Profile["plan"], number | null> = {
   free: 5,
   plus: null,
   pro: null,
 };
 
+/**
+ * Returns whether the provided profile can create another collection based on
+ * their plan limit. This helper is intentionally tiny so it can be imported into
+ * both server actions (authoritative checks) and client components (UI gating)
+ * without pulling in heavy dependencies.
+ */
 export function canCreateCollection(profile: Profile, currentCount: number) {
   const limit = PLAN_COLLECTION_LIMIT[profile.plan];
   if (limit === null) return true;
   return currentCount < limit;
 }
 
+/**
+ * Produces a human-readable message for plan gating banners when a user reaches
+ * their limit. Keeping message construction here means marketing copy is
+ * consistent across dashboard banners and toast notifications.
+ */
 export function planGateMessage(profile: Profile) {
   const limit = PLAN_COLLECTION_LIMIT[profile.plan];
   if (limit === null) return "";

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -1,3 +1,10 @@
+/**
+ * Attempts to determine the originating client IP address from common proxy
+ * headers. API routes use this helper to enforce per-IP rate limits without
+ * caring which hosting provider (Vercel, Cloudflare, etc.) is in front of the
+ * app. The header precedence mirrors Vercel's behaviour—`x-forwarded-for` first
+ * followed by `x-real-ip`—with a final fallback to Cloudflare's header.
+ */
 export function getClientIp(request: Request) {
   const forwarded = request.headers.get("x-forwarded-for");
   if (forwarded) {

--- a/src/lib/slugs.ts
+++ b/src/lib/slugs.ts
@@ -1,3 +1,14 @@
+/**
+ * Slug helpers used for both public collection URLs and internal dashboards.
+ * Centralising the logic ensures server actions and UI components agree on how
+ * slugs are generated and deduplicated.
+ */
+
+/**
+ * Produces a URL-safe slug by lowercasing, replacing ampersands, and collapsing
+ * whitespace/punctuation. The resulting string is suitable for inclusion in a
+ * route segment.
+ */
 export function slugify(input: string) {
   return input
     .trim()
@@ -8,6 +19,12 @@ export function slugify(input: string) {
     .replace(/-{2,}/g, "-");
 }
 
+/**
+ * Ensures a slug is unique within the provided set by appending incrementing
+ * counters when needed. The returned slug is guaranteed to not appear in the
+ * `existing` collection, allowing callers to safely persist the value without a
+ * second query.
+ */
 export function ensureUniqueSlug(base: string, existing: Set<string>) {
   const slug = slugify(base);
   if (!existing.has(slug)) return slug;

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,12 +1,28 @@
 "use client";
 
+/**
+ * Browser-side Supabase client factory. Client components use this module to
+ * interact with Supabase without duplicating environment plumbing or worrying
+ * about repeated client instantiation.
+ */
+
 import { createBrowserClient } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { getClientEnv } from "@/env";
 import type { Database } from "./types";
 
+/**
+ * Cached singleton instance of the browser Supabase client. Ensures we only
+ * create one per session and reuse it across renders.
+ */
 let client: SupabaseClient<Database> | null = null;
 
+/**
+ * Lazily instantiates and returns the browser Supabase client configured with
+ * public credentials. The `suppressGetSessionWarning` flag is set because we
+ * always revalidate sessions with `auth.getUser()` on the server, making the
+ * SSR warning redundant for this architecture.
+ */
 export function getSupabaseBrowserClient() {
   if (!client) {
     const { NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY } = getClientEnv();

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,3 +1,9 @@
+/**
+ * Next.js server-side Supabase client factories. These helpers make it trivial
+ * for route handlers and server components to read/write Supabase data while
+ * automatically wiring cookie persistence.
+ */
+
 import { cookies } from "next/headers";
 import { cache } from "react";
 import { createServerClient } from "@supabase/ssr";
@@ -21,6 +27,13 @@ interface MutableCookieStore extends CookieStore {
   delete?: (name: string, options?: CookieOptions) => void;
 }
 
+/**
+ * Creates a Supabase client configured for server-side execution within Next.js,
+ * wiring cookie persistence so auth state survives across requests and server
+ * actions. The cookie adapter gracefully handles calls from environments where
+ * the cookie store is immutable (e.g., during rendering) by swallowing the
+ * update with a development warning.
+ */
 export async function createSupabaseServerClient(cookieStore?: CookieStore) {
   const store = cookieStore ?? (await cookies());
   const { NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY } = getServerEnv();
@@ -65,4 +78,9 @@ export async function createSupabaseServerClient(cookieStore?: CookieStore) {
   return client;
 }
 
+/**
+ * Cached helper that reuses a single server client within a request lifecycle.
+ * Wrapping with `cache` prevents redundant instantiations when multiple
+ * components call the helper during a single request.
+ */
 export const getSupabaseServerClient = cache(async () => createSupabaseServerClient());

--- a/src/lib/supabase/service.ts
+++ b/src/lib/supabase/service.ts
@@ -1,9 +1,24 @@
+/**
+ * Service-role Supabase client factory. This elevated client is required for
+ * tasks that need bypassed RLS policies such as caching TMDB movies or creating
+ * profile records on behalf of a user.
+ */
+
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { getServerEnv } from "@/env";
 import type { Database } from "./types";
 
+/**
+ * Cached service-role Supabase client used for privileged operations such as
+ * background caching.
+ */
 let serviceClient: SupabaseClient<Database> | null = null;
 
+/**
+ * Returns the shared service-role client, creating it on first use with
+ * non-persistent auth. Tokens are intentionally non-refreshing because the
+ * service key never expires and we do not want ambient background refresh jobs.
+ */
 export function getSupabaseServiceRoleClient() {
   if (!serviceClient) {
     const { NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = getServerEnv();

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1,7 +1,17 @@
+/**
+ * Types generated from the Supabase schema. These interfaces power strong
+ * typing across server actions and React components by mirroring the structure
+ * of our Postgres tables. Regenerate the file whenever the database schema
+ * changes to keep TypeScript accurate.
+ */
 export type Plan = "free" | "plus" | "pro";
 
 export type WatchStatus = "watched" | "watching" | "want";
 
+/**
+ * Root database contract consumed by the Supabase client helpers. The nested
+ * structure matches the format expected by `@supabase/supabase-js`.
+ */
 export interface Database {
   public: {
     Tables: {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,14 +1,31 @@
+/**
+ * Miscellaneous UI utilities that appear across the React component tree.
+ */
+
 import { clsx, type ClassValue } from "clsx";
 
+/**
+ * Joins a variable number of class name values into a single string, skipping
+ * falsy inputs. This thin wrapper exists so that consuming components only
+ * import from our shared utilities.
+ */
 export function cn(...inputs: ClassValue[]) {
   return clsx(...inputs);
 }
 
+/**
+ * Truncates long text to the desired maximum length, appending an ellipsis when trimming occurs.
+ * Used anywhere we display user-generated strings in constrained UI elements.
+ */
 export function truncate(text: string, max = 140) {
   if (text.length <= max) return text;
   return `${text.slice(0, max - 1)}…`;
 }
 
+/**
+ * Normalises error values into user-friendly messages while falling back to a safe default.
+ * Accepts raw strings, `Error` instances, or unknown objects that include a `message` property.
+ */
 export function formatError(error: unknown, fallback = "Something went wrong") {
   if (!error) return fallback;
   if (typeof error === "string") return error;

--- a/src/types/collection.ts
+++ b/src/types/collection.ts
@@ -1,11 +1,17 @@
 import type { Collection, CollectionItem, Movie, Profile } from "@/lib/supabase/types";
 import type { MovieSummary } from "@/lib/tmdb";
 
+/**
+ * Collection enriched with owner details and preloaded items for dashboard views.
+ */
 export interface CollectionWithItems extends Collection {
   owner: Pick<Profile, "id" | "username" | "display_name">;
   items: CollectionItemWithMovie[];
 }
 
+/**
+ * Collection item that includes cached TMDB metadata when available.
+ */
 export interface CollectionItemWithMovie extends CollectionItem {
   movie: MovieSummary | (Movie & { overview?: string | null; vote_average?: number | null }) | null;
 }


### PR DESCRIPTION
## Summary
- document authentication, plan, TMDB, and Supabase helpers with detailed module- and function-level comments for easier onboarding
- annotate authenticated layouts, dashboards, editors, public pages, and provider components so data flow and server action usage are clear end-to-end
- expand the README documentation section to point developers toward the inline comments now available across the repo

## Testing
- npm run lint *(fails: missing optional dependency `@eslint/eslintrc` in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d60dd743f0832fb044ecacbc7a295f